### PR TITLE
Dev vcr changes

### DIFF
--- a/tests/testthat/setup-rtoot.R
+++ b/tests/testthat/setup-rtoot.R
@@ -13,4 +13,3 @@ invisible(
     dir = vcr::vcr_test_path("fixtures")
   )
 )
-vcr::check_cassette_names()


### PR DESCRIPTION
check_cassette_names is being deprecated, you can wait until the next version of vcr for it to be removed but might as well remove now. 

in addition, I see some errors running tests - i suggest installing dev vcr `pak::pak("ropensci/vcr")` and re-recording cassettes